### PR TITLE
Updates for k8s 1.16 compatibility

### DIFF
--- a/001-nfs-server.yaml
+++ b/001-nfs-server.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nfs-server-<NUMBER>

--- a/deployment-http-fileserver.yaml
+++ b/deployment-http-fileserver.yaml
@@ -8,6 +8,9 @@ metadata:
 spec:
   replicas: 1
   strategy: {}
+  selector:
+    matchLabels:
+      service: http-fileserver
   template:
     metadata:
       labels:


### PR DESCRIPTION
Updates two manifests for  g8s 1.16 compatibility, corresponding updates done in the instructions https://github.com/cms-opendata-workshop/workshop-lesson-kubernetes/pull/20